### PR TITLE
Remove mem benchmarks

### DIFF
--- a/benchmarks/benchmarks/bench_alphabet.py
+++ b/benchmarks/benchmarks/bench_alphabet.py
@@ -40,9 +40,5 @@ class AlphabetSuite:
         alphabet(self.data)
 
     @skip_params_if(skip, os.getenv("QUICK_BENCHMARK") == "true")
-    def mem_alphabet(self, length, case):
-        return alphabet(self.data)
-
-    @skip_params_if(skip, os.getenv("QUICK_BENCHMARK") == "true")
     def peakmem_alphabet(self, length, case):
         return alphabet(self.data)

--- a/benchmarks/benchmarks/bench_ma_alphabet.py
+++ b/benchmarks/benchmarks/bench_ma_alphabet.py
@@ -44,9 +44,5 @@ class MaAlphabetSuite:
         alphabet(self.data)
 
     @skip_params_if(skip, os.getenv("QUICK_BENCHMARK") == "true")
-    def mem_alphabet(self, length, case):
-        return alphabet(self.data)
-
-    @skip_params_if(skip, os.getenv("QUICK_BENCHMARK") == "true")
     def peakmem_alphabet(self, length, case):
         return alphabet(self.data)

--- a/benchmarks/benchmarks/bench_ma_order.py
+++ b/benchmarks/benchmarks/bench_ma_order.py
@@ -44,9 +44,5 @@ class MaOrderSuite:
         order(self.data)
 
     @skip_params_if(skip, os.getenv("QUICK_BENCHMARK") == "true")
-    def mem_order(self, length, case):
-        return order(self.data)
-
-    @skip_params_if(skip, os.getenv("QUICK_BENCHMARK") == "true")
     def peakmem_order(self, length, case):
         return order(self.data)

--- a/benchmarks/benchmarks/bench_order.py
+++ b/benchmarks/benchmarks/bench_order.py
@@ -40,9 +40,5 @@ class OrderSuite:
         order(self.data)
 
     @skip_params_if(skip, os.getenv("QUICK_BENCHMARK") == "true")
-    def mem_order(self, length, case):
-        return order(self.data)
-
-    @skip_params_if(skip, os.getenv("QUICK_BENCHMARK") == "true")
     def peakmem_order(self, length, case):
         return order(self.data)


### PR DESCRIPTION
## What
* Remove mem benchmarks for `alphabet`
* Remove mem benchmarks for `ma.alphabet`
* Remove mem benchmarks for `order`
* Remove mem benchmarks for `ma.order`

## Why
* The memory benchmarks are useless but take time.