### PR TITLE
Fix ma namespaces

### DIFF
--- a/src/foapy/ma/__init__.py
+++ b/src/foapy/ma/__init__.py
@@ -1,0 +1,17 @@
+import sys
+
+# We first need to detect if we're being called as part of the numpy setup
+# procedure itself in a reliable manner.
+try:
+    __FOAPY_SETUP__
+except NameError:
+    __FOAPY_SETUP__ = False
+
+if __FOAPY_SETUP__:
+    sys.stderr.write("Running from numpy source directory.\n")
+else:
+    from .alphabet import alphabet  # noqa: F401
+    from .intervals import intervals  # noqa: F401
+    from .order import order  # noqa: F401
+
+    __all__ = list({"order", "intervals", "alphabet"})

--- a/src/foapy/ma/order.py
+++ b/src/foapy/ma/order.py
@@ -3,7 +3,7 @@ import numpy.ma as ma
 
 from foapy import order as general_order
 from foapy.exceptions import Not1DArrayException
-from foapy.ma.alphabet import alphabet
+from foapy.ma import alphabet
 
 
 def order(X, return_alphabet=False) -> np.ma.MaskedArray:

--- a/tests/test_ma_alphabet.py
+++ b/tests/test_ma_alphabet.py
@@ -5,7 +5,7 @@ import pytest
 from numpy.ma.testutils import assert_equal
 
 from foapy.exceptions import InconsistentOrderException, Not1DArrayException
-from foapy.ma.alphabet import alphabet
+from foapy.ma import alphabet
 
 
 class TestMaAlphabet(TestCase):

--- a/tests/test_ma_intervals.py
+++ b/tests/test_ma_intervals.py
@@ -6,7 +6,7 @@ import pytest
 from numpy.ma.testutils import assert_equal
 
 from foapy.exceptions import InconsistentOrderException, Not1DArrayException
-from foapy.ma.intervals import intervals
+from foapy.ma import intervals
 
 
 class TestMaIntervals(TestCase):

--- a/tests/test_ma_order.py
+++ b/tests/test_ma_order.py
@@ -5,7 +5,7 @@ import pytest
 from numpy.ma.testutils import assert_equal
 
 from foapy.exceptions import InconsistentOrderException, Not1DArrayException
-from foapy.ma.order import order
+from foapy.ma import order
 
 
 class TestMaOrder(TestCase):


### PR DESCRIPTION
## What
* Fix pip package `ma` namespace

## Why
* Make methods public