### PR TITLE
Improve redundant mode

### DIFF
--- a/src/foapy/intervals.py
+++ b/src/foapy/intervals.py
@@ -1,63 +1,89 @@
 import numpy as np
 
-from foapy import binding, mode
+import foapy.constants_intervals as constants
 
 
-def intervals(X, bind, mod):
+def intervals(X, binding, mode):
     """
-    Find a one-dimensional array of intervals in the
-    given input sequence with the interval binding determined
-    by the provided binding and mode flags.
 
-    Parameters
-    ----------
-    X: one-dimensional array
-        Array to get unique values.
-    binding: int
-        start = 1 - Intervals are extracted from left to right.
-        end = 2 – Intervals are extracted from right to left.
-    mode: int
-        lossy = 1 - Both interval from the start of the sequence
-        to the first element occurrence and interval from the
-        last element occurrence to the end of the sequence
-        are not taken into account.
+    Function to extract intervals from a sequence.
 
-        normal = 2 - Interval from the start of the sequence to
-        the first occurrence of the element
-        (in case of binding to the beginning)
-        or interval from the last occurrence of the element to
-        the end of the sequence
-        (in case of binding to the end) is taken into account.
+    An interval is defined as the distance between consecutive occurrences
+    of elements in the sequence, with boundary intervals counted as positions
+    from sequence edges to first/last occurrence. The intervals are extracted
 
-        cycle = 3 - Interval from the start of the sequence to
-        the first element occurrence
-        and interval from the last element occurrence to the
-        end of the sequence are summed
-        into one interval (as if sequence was cyclic).
-        Interval is placed either in the beginning of
-        intervals array (in case of binding to the beginning)
-        or in the end (in case of binding to the end).
+    === "binding.end"
 
-        redundant = 4 - Both interval from start of the sequence
-        to the first element occurrence and the interval from
-        the last element occurrence to the end of the
-        sequence are taken into account. Their placement in results
-        array is determined
-        by the binding.
-    Returns
-    -------
-    result: array or error.
-        An error indicating that the binding or mode does not exist,
-        otherwise the array.
+        |         |  b |  a |  b |  c |  b |
+        |:-------:|:--:|:--:|:--:|:--:|:--:|
+        | b       |  2 | <- |  2 | <- |  1 |
+        | a       |    |  4 | <- | <- | <- |
+        | c       |    |    |    |  2 | <- |
+        | result  |  2 |  4 |  2 |  2 |  1 |
+
+    The mode parameter determines how to handle the intervals at the
+    sequence boundaries:
+    - normal: Include first/last boundary interval based on binding
+    - cycle: Combine boundary intervals as one cyclic interval
+    - redundant: Include both boundary intervals
+    - lossy: Ignore boundary intervals
+
+    Example how different modes handle intervals are extracted when binding.start
+
+    === "mode.normal"
+
+        |        |  b |  a |  b |  c |  b |
+        |:------:|:--:|:--:|:--:|:--:|:--:|
+        | b      |  1 | -> |  2 | -> |  2 |
+        | a      | -> |  2 |    |    |    |
+        | c      | -> | -> | -> |  4 |    |
+        | result |  1 |  2 |  2 |  4 |  2 |
+
+    === "mode.cycle"
+
+        |        | transition |  a |  b |  c |  b |  b | transition |
+        |:------:|:----------:|:--:|:--:|:--:|:--:|:--:|:----------:|
+        | b      |     (1)    |  1 | -> |  2 | -> |  2 |     (1)    |
+        | a      |     (2)    | -> |  5 | -> | -> | -> |     (2)    |
+        | c      |     (3)    | -> | -> | -> |  5 | -> |     (3)    |
+        | result |            |  1 |  5 |  2 |  5 |  2 |            |
+
+    === "mode.lossy"
+
+        |        |  b |  a |  b |  c |  b |
+        |:------:|:--:|:--:|:--:|:--:|:--:|
+        | b      |  x | -> |  2 | -> |  2 |
+        | a      | -> |  x |    |    |    |
+        | c      | -> | -> | -> |  x |    |
+        | result |    |    |  2 |    |  2 |
+
+    === "mode.redundant"
+
+        |        |  a |  b |  c |  b |  b | end   |
+        |:------:|:--:|:--:|:--:|:--:|:--:|:-----:|
+        | b      |  1 | -> |  2 | -> |  2 | 1     |
+        | a      | -> |  2 | -> | -> | -> | 4     |
+        | c      | -> | -> | -> |  4 | -> | 2     |
+        | result |  1 |  2 |  2 |  4 |  2 | 1 4 2 |
+    # Not1DArrayException:
+    # {'message': 'Incorrect array form. Expected d1 array, exists 2'}
+    ```
     """
+
     # Validate binding
-    if bind not in {binding.start, binding.end, 1, 2}:
+    if binding not in {constants.binding.start, constants.binding.end}:
         raise ValueError(
             {"message": "Invalid binding value. Use binding.start or binding.end."}
         )
 
     # Validate mode
-    if mod not in {mode.lossy, mode.normal, mode.cycle, mode.redundant, 1, 2, 3, 4}:
+    valid_modes = [
+        constants.mode.lossy,
+        constants.mode.normal,
+        constants.mode.cycle,
+        constants.mode.redundant,
+    ]
+    if mode not in valid_modes:
         raise ValueError(
             {"message": "Invalid mode value. Use mode.lossy,normal,cycle or redundant."}
         )
@@ -67,7 +93,7 @@ def intervals(X, bind, mod):
     if ar.shape == (0,):
         return []
 
-    if bind == binding.end:
+    if binding == constants.binding.end:
         ar = ar[::-1]
 
     perm = ar.argsort(kind="mergesort")
@@ -84,29 +110,27 @@ def intervals(X, bind, mod):
     intervals = np.empty(ar.shape, dtype=np.intp)
     intervals[1:] = perm[1:] - perm[:-1]
 
-    delta = len(ar) - perm[last_mask] if mod == mode.cycle else 1
+    delta = len(ar) - perm[last_mask] if mode == constants.mode.cycle else 1
     intervals[first_mask] = perm[first_mask] + delta
 
     inverse_perm = np.empty(ar.shape, dtype=np.intp)
     inverse_perm[perm] = np.arange(ar.shape[0])
 
-    if mod == mode.lossy:
+    if mode == constants.mode.lossy:
         intervals[first_mask] = 0
         intervals = intervals[inverse_perm]
         result = intervals[intervals != 0]
-    elif mod == mode.normal:
+    elif mode == constants.mode.normal:
         result = intervals[inverse_perm]
-    elif mod == mode.cycle:
+    elif mode == constants.mode.cycle:
         result = intervals[inverse_perm]
-    elif mod == mode.redundant:
-        result = np.zeros(shape=ar.shape + (2,), dtype=int)
-        result[:, 0] = intervals
-        result[last_mask, 1] = len(ar) - perm[last_mask]
-        result = result[inverse_perm]
-        result = result.ravel()
-        result = result[result != 0]
-
-    if bind == binding.end:
+    elif mode == constants.mode.redundant:
+        result = intervals[inverse_perm]
+        redundant_intervals = len(ar) - perm[last_mask]
+        if binding == constants.binding.end:
+            redundant_intervals = redundant_intervals[::-1]
+        result = np.concatenate((result, redundant_intervals))
+    if binding == constants.binding.end:
         result = result[::-1]
 
     return result

--- a/tests/test_intervals.py
+++ b/tests/test_intervals.py
@@ -98,7 +98,7 @@ class TestIntervals(TestCase):
 
     def test_int_start_redundant(self):
         X = [2, 4, 2, 2, 4]
-        expected = np.array([1, 2, 2, 1, 2, 3, 1])
+        expected = np.array([1, 2, 2, 1, 3, 2, 1])
         exists = intervals(X, binding.start, mode.redundant)
         assert_array_equal(expected, exists)
 
@@ -122,7 +122,7 @@ class TestIntervals(TestCase):
 
     def test_dna_start_redundant(self):
         X = ["ATC", "CTG", "ATC"]
-        expected = np.array([1, 2, 2, 2, 1])
+        expected = np.array([1, 2, 2, 1, 2])
         exists = intervals(X, binding.start, mode.redundant)
         assert_array_equal(expected, exists)
 


### PR DESCRIPTION
## What
* Add redundant intervals to the end of the intervals array instead of after the last appearance of an element

## Why
* Easy to explain
* Easy to compute - memory usage reduced
* Easy to create reverse procedure

### Prev

```
X = [2, 4, 2, 2, 4]
expected = np.array([1, 2, 2, 1, 2, 3, 1])
exists = intervals(X, binding.start, mode.redundant)
assert_array_equal(expected, exists)
```

### New 

```
X = [2, 4, 2, 2, 4]
expected = np.array([1, 2, 2, 1, 3,  2, 1])
#.                                                     ^ Here redundant intervals started
exists = intervals(X, binding.start, mode.redundant)
assert_array_equal(expected, exists)
```

|        |  a |  b |  c |  b |  b | end   |
|:------:|:--:|:--:|:--:|:--:|:--:|:-----:|
| b      |  1 | -> |  2 | -> |  2 | 1     |
| a      | -> |  2 | -> | -> | -> | 4     |
| c      | -> | -> | -> |  4 | -> | 2     |
| result |  1 |  2 |  2 |  4 |  2 | 1 4 2 |

Tests would looks like

```
def test_int_start_redundant(self):
        X = [2, 4, 2, 2, 4]
        expected = np.array([1, 2, 2, 1, 3, 2, 1])
        exists = intervals(X, binding.start, mode.redundant)
        assert_array_equal(expected, exists)

    def test_int_end_redundant(self):
        X = [2, 4, 2, 2, 4]
        expected = np.array([1, 2, 2, 3, 1, 2, 1])
        exists = intervals(X, binding.end, mode.redundant)
```